### PR TITLE
I2C Bus number changed to 2 since at least Debian 8.4

### DIFF
--- a/utils/ina219.c
+++ b/utils/ina219.c
@@ -33,7 +33,7 @@ typedef enum {
 op_type operation = OP_DUMP;
 
 int interval = 60;
-int i2c_bus = 1;
+int i2c_bus = 2;
 int i2c_address = INA_ADDRESS;
 int handle;
 int whole_numbers = 0;

--- a/utils/powercape.c
+++ b/utils/powercape.c
@@ -31,7 +31,7 @@ typedef enum
 
 op_type operation = OP_NONE;
 
-int i2c_bus = 1;
+int i2c_bus = 2;
 int handle;
 
 


### PR DESCRIPTION
I am probably not the only one that has to manually change the i2c bus number every time I clone the repo. I don't know why the bus is specified as 1, maybe in Debian 7 or Angstrom it was the number given at boot time enumeration?